### PR TITLE
Second URL link on page to ‘Mailing List’ gives error page 404

### DIFF
--- a/site/src/site/pages/contribute.groovy
+++ b/site/src/site/pages/contribute.groovy
@@ -59,7 +59,7 @@ layout 'layouts/main.groovy', true,
                                     yield '''
                                         If you encounter a problem, want to discuss a new feature,
                                         share interesting findings, and more, then the '''
-                                    a(href: 'mailing-lists.html', 'mailing-lists')
+                                    a(href: 'http://groovy-lang.org/mailing-lists.html', 'mailing-lists')
                                     yield '''
                                         are the place to go to start a conversation with the Groovy developers
                                         and other Groovy users. Discussions on the mailing list are archived.


### PR DESCRIPTION
There are two links to ‘Mailing List’ on this page: line 23 and line 62.

The second one (line 62) does not work for me, and gives a error page 404 when i click on it. The first link (line 23) does work ok.

This change proposes to make the working URL link on line 23 the same at line 62.