### PR TITLE
Change sort order of ATOM Feed

### DIFF
--- a/generator/src/main/groovy/generator/SiteGenerator.groovy
+++ b/generator/src/main/groovy/generator/SiteGenerator.groovy
@@ -287,7 +287,7 @@ class SiteGenerator {
 
     @CompileDynamic
     private void renderBlogFeed(Map<String, Document> blogList, String baseDir) {
-        def sorted = blogList.sort { e -> e.value.revisionInfo.date }
+        def sorted = blogList.sort { e -> e.value.revisionInfo.date.reverse() }
         def base = "http://groovy.apache.org/$baseDir"
         def feedDir = new File(outputDir, baseDir)
         feedDir.mkdirs()


### PR DESCRIPTION
Reversed the sort order to have most recent post first. This lets us integrate this feed into common RSS readers as well as tools such as N8N and Zapier.