### PR TITLE
Docs: explain breaking long lines in Groovy

### DIFF
--- a/site/src/site/wiki/core-syntax.adoc
+++ b/site/src/site/wiki/core-syntax.adoc
@@ -1,0 +1,34 @@
+=== Breaking long lines
+
+To improve readability or comply with line length checks, Groovy allows
+expressions to be split across multiple lines.
+
+Function calls can be broken across lines:
+
+[source,groovy]
+----
+someVeryLongFunctionName(
+    firstArgument,
+    secondArgument,
+    thirdArgument
+)
+----
+
+Strings can be split using concatenation:
+
+[source,groovy]
+----
+def text = 'This is a very long string ' +
+           'that is split across multiple lines'
+----
+
+Collections can also span multiple lines:
+
+[source,groovy]
+----
+def numbers = [
+    1, 2, 3,
+    4, 5, 6
+]
+----
+


### PR DESCRIPTION
Fixes #64

This PR enhances the Groovy documentation by adding guidance on how to
break long lines into multiple lines, which is helpful when addressing
linter warnings such as LineLength.

The documentation includes a clear example showing how collections can
span multiple lines, improving readability and maintainability.

If this content would be better placed in an existing documentation
section or requires adjustment to match project conventions, I’m happy
to update it based on maintainer feedback.
