### PR TITLE
Fix typos and improve grammar in release notes and blog posts

### DIFF
--- a/site/src/site/blog/classifying-iris-flowers-with-deep.adoc
+++ b/site/src/site/blog/classifying-iris-flowers-with-deep.adoc
@@ -290,7 +290,7 @@ There is the Encog jar, the JSR381 VisRec API which is in a separate jar, and a 
 
 Another technology we might want to consider if performance is important to us is https://www.graalvm.org/[GraalVM]. GraalVM is a high-performance JDK distribution designed to speed up the execution of applications written in Java and other JVM languages. We'll look at creating a native version of our Iris Deep Netts application. We used GraalVM 22.1.0 Java 17 CE and Groovy 4.0.3. We'll cover just the basic steps but there are other places for additional setup info and troubleshooting help like https://e.printstacktrace.blog/graalvm-and-groovy-how-to-start/[here], https://github.com/wololock/gttp[here] and https://simply-how.com/fix-graalvm-native-image-compilation-issues[here].
 
-Groovy has two natures. It's dynamic nature supports adding methods at runtime through metaprogramming
+Groovy has two natures. Its dynamic nature supports adding methods at runtime through metaprogramming
 and interacting with method dispatch processing through missing method interception and other tricks.
 Some of these tricks make heavy use of reflection and dynamic class loading and cause problems for
 GraalVM which is trying to determine as much information as it can at compile time. Groovy's static

--- a/site/src/site/blog/embabel-agentic-patterns.adoc
+++ b/site/src/site/blog/embabel-agentic-patterns.adoc
@@ -11,7 +11,7 @@ excellent arguments as to the benefits of a JVM solution over LangGraph and Pyth
 We won't repeat those arguments here, but we highly recommend that you read Rod's article.
 
 This blog post looks at those same examples using Groovy. Groovy is sometimes referred to
-as the Python of the JVM world. It's syntax mostly resembles Java but some of its features
+as the Python of the JVM world. Its syntax mostly resembles Java but some of its features
 will be familiar to Python programmers. So, for Python folks who want to try out some JVM
 AI frameworks, Groovy might be a nice entry point.
 Also, for Groovy folks, we want to show them how easy it is to use powerful JVM frameworks like Embabel.

--- a/site/src/site/blog/solving-simple-optimization-problems-with-groovy.adoc
+++ b/site/src/site/blog/solving-simple-optimization-problems-with-groovy.adoc
@@ -216,7 +216,7 @@ At this stage, it isn't clear how the two projects will evolve over time.
 
 One of the claims of the Timefold project is that it has a lighter dependency footprint.
 This can be confirmed by running the `printRuntimeClasspath` task in the associated builds.
-Timefold has 20 dependant jars compared with OptaPlanner's 55 jars.
+Timefold has 20 dependent jars compared with OptaPlanner's 55 jars.
 
 While Timefold's power isn't needed for our simple problem,
 let's examine how you would use it for the same case study.

--- a/site/src/site/releasenotes/groovy-1.6.adoc
+++ b/site/src/site/releasenotes/groovy-1.6.adoc
@@ -246,7 +246,7 @@ assert method(true) == 2
 == AST Transformations
 
 Although at times, it may sound like a good idea to extend the syntax of
-Groovy to implement new features (like this is the case for instance for
+Groovy to implement new features (as is the case, for instance, for
 multiple assignments), most of the time, we can't just add a new keyword
 to the grammar, or create some new syntax construct to represent a new
 concept. However, with the idea of AST (Abstract Syntax Tree)
@@ -1103,7 +1103,7 @@ runtime system, bringing several new capabilities into the mix.
 
 So far, Groovy POGOs (Plain Old Groovy Objects) could have a
 per-instance metaclass, but POJOs could only have one metaclass for all
-instances (i.e. a per-class metaclass). This is now not the case anymore,
+instances (i.e. a per-class metaclass). This is no longer the case,
 as POJOs can have a per-instance metaclass too. Also, setting the
 metaclass property to null will restore the default metaclass.
 

--- a/site/src/site/releasenotes/groovy-1.6.adoc
+++ b/site/src/site/releasenotes/groovy-1.6.adoc
@@ -427,7 +427,7 @@ assert p.dump().contains('Cat')
 
 In the case of complex computation for initializing the field, you may
 need to call some method for doing the work, instead of a value like our
-pets list. This is then possible to have the lazy evaluation being done
+pets list. It is then possible to have the lazy evaluation being done
 by a closure call, as the following example shows:
 
 [source,groovy]

--- a/site/src/site/releasenotes/groovy-1.7.adoc
+++ b/site/src/site/releasenotes/groovy-1.7.adoc
@@ -263,7 +263,7 @@ writers: an AST viewer and an AST builder.
 The following screenshot shows a new window that can be launched from
 the Groovy Swing Console. You can visualize the AST of a script you’re
 working on in the console: for instance, writing the code you’d like to
-create in your AST transformation. The AST viewer greatly help with
+create in your AST transformation. The AST viewer greatly helps with
 figuring out how Groovy builds its AST when compiling your Groovy
 code. +
 image:img/AstBrowser.png[image]
@@ -360,7 +360,7 @@ assert new Predicate(value: true)
 assert !new Predicate(value: false)
 -----------------------------------
 
-Is is also possible to use categories or ExpandoMetaClass to inject an
+It is also possible to use categories or ExpandoMetaClass to inject an
 `asBoolean()` method, or to override an existing one (even one on the
 small set of classes with special Groovy truth behavior).
 

--- a/site/src/site/releasenotes/groovy-1.8.adoc
+++ b/site/src/site/releasenotes/groovy-1.8.adoc
@@ -1342,7 +1342,7 @@ The compilation of Groovy code can be configured through the
 your sources, the base script class, the recompilation parameters, etc).
 `CompilerConfiguration` now has a new option for setting _compilation
 customizers_ (belonging to the `org.codehaus.groovy.control.customizers`
-package). Those customizers allow to customize the compilation process
+package). Those customizers allow you to customize the compilation process
 in three ways:
 
 * adding default imports with the `ImportCustomizer`: so you don’t have

--- a/site/src/site/releasenotes/groovy-1.8.adoc
+++ b/site/src/site/releasenotes/groovy-1.8.adoc
@@ -1221,9 +1221,9 @@ slashes):
 // match yyyy-mm-dd from this or previous century
 def dateRegex = /(?x)     # enable whitespace and comments
 ((?:19|20)\d\d)           # year (group 1) (non-capture alternation for century)
--                         # seperator
+-                         # separator
 (0[1-9]|1[012])           # month (group 2)
--                         # seperator
+-                         # separator
 (0[1-9]|[12][0-9]|3[01])  # day (group 3)
 /
 
@@ -1300,9 +1300,9 @@ style (particularly ones which contain slashes):
 // match yyyy-mm-dd from current or previous century
 def dateRegex = $/(?x)    # enable whitespace and comments
 ((?:19|20)\d\d)           # year (group 1) (non-capture alternation for century)
-[- /.]                    # seperator
+[- /.]                    # separator
 (0[1-9]|1[012])           # month (group 2)
-[- /.]                    # seperator
+[- /.]                    # separator
 (0[1-9]|[12][0-9]|3[01])  # day (group 3)
 /$
 

--- a/site/src/site/releasenotes/groovy-2.0.adoc
+++ b/site/src/site/releasenotes/groovy-2.0.adoc
@@ -763,7 +763,7 @@ required if implementing in Java) and static (although they will be
 available on instances of that class). They will always take a first
 parameter which is actually the instance on which this method will be
 called. And then following parameters will be the parameters passed when
-calling the method. This is the same convention use for Groovy
+calling the method. This is the same convention used for Groovy
 categories. +
   +
 Say we want to add a greets() method on String, that would greet the

--- a/site/src/site/releasenotes/groovy-2.1.adoc
+++ b/site/src/site/releasenotes/groovy-2.1.adoc
@@ -178,7 +178,7 @@ checking your DSLs, as you shall see in the following section.
 Before moving on, let’s mention a few closing details
 about `@DelegatesTo`.
 
-`@DelegatesTo` allows to specify the receiver calls are delegated to.
+`@DelegatesTo` allows you to specify the receiver calls are delegated to.
 For instance, when a delegate calls a method or property on another
 method parameter. Imagine our `exec()` method taking
 the `Executor` argument instance as delegate:
@@ -430,7 +430,7 @@ obscure the general intent of that particular combination.
 
 To group annotations together, to make the intent clearer or to
 streamline your code, Groovy 2.1 offers a *meta-annotation system, which
-allows to combine other annotations into one "alias" annotation*.
+allows you to combine other annotations into one "alias" annotation*.
 
 Imagine we are using some annotations defining constraints on properties
 of your class, like `@NotNull`, `@Length`, or `@Pattern`, which could be

--- a/site/src/site/releasenotes/groovy-2.4.adoc
+++ b/site/src/site/releasenotes/groovy-2.4.adoc
@@ -26,7 +26,7 @@ And discover presentations on the Android support:
 * link:https://speakerdeck.com/melix/groovy-and-android-a-winning-pair-1[Groovy and Android, a winning pair] by Cédric Champeau
 * link:https://speakerdeck.com/glaforge/groovy-on-android-groovy-grails-exchange-2014[Groovy on Android] by Guillaume Laforge
 
-The work on the Android support also lead to various optimizations in
+The work on the Android support also led to various optimizations in
 terms of bytecode generation, as explained further down, as well as, for
 instance, improving the handling of overloaded setters
 (link:https://issues.apache.org/jira/browse/GROOVY-2049[GROOVY-2049],link:https://issues.apache.org/jira/browse/GROOVY-6084[GROOVY-6084],
@@ -145,7 +145,7 @@ methods if needed
 * Clean up generated code for `@AutoExternalizable`
 (link:https://issues.apache.org/jira/browse/GROOVY-6889[GROOVY-6889]) and
 `@EqualsAndHashCode`
-(link:https://issues.apache.org/jira/browse/GROOVY-6893[GROOVY-6893]) the when
+(link:https://issues.apache.org/jira/browse/GROOVY-6893[GROOVY-6893]) when
 using `@CompileStatic`
 * `@Builder`’s default and initializer strategies improved Java
 integration (link:https://issues.apache.org/jira/browse/GROOVY-6875[GROOVY-6875])
@@ -165,7 +165,7 @@ startup (link:https://issues.apache.org/jira/browse/GROOVY-6943[GROOVY-6943])
 (link:https://issues.apache.org/jira/browse/GROOVY-6622[GROOVY-6622])
 * completion candidates in color
 (link:https://issues.apache.org/jira/browse/GROOVY-6563[GROOVY-6563])
-* with :set interpreterMode true, you can let Groovysh to let you see
+* with :set interpreterMode true, you can allow Groovysh to let you see
 and use locally-defined variables after further line executions
 (link:https://issues.apache.org/jira/browse/GROOVY-6623[GROOVY-6623])
 * the :load command supports file names containing spaces


### PR DESCRIPTION
I was going through the documentation and saw a handful of small typos and grammar slips that felt worth fixing. Specifically, I've updated:

- Small spelling typos (e.g., "dependant" -> "dependent", "lead" -> "led")
- Grammar fixes (e.g., "greatly help" -> "greatly helps")
- Natural phrasing (e.g., changing "allows to" to "allows you to" for a better flow)

No code was changed, just some of the `.adoc` content files.